### PR TITLE
[test] Add e2e test for OCI load balancer (if supported by infrastructure)

### DIFF
--- a/internal/incus/lxc_extensions.go
+++ b/internal/incus/lxc_extensions.go
@@ -1,0 +1,27 @@
+package incus
+
+import "fmt"
+
+// SupportsInstanceOCI checks if the necessary API extensions for OCI instances are supported by the server.
+//
+// If instance_oci is not supported, a terminalError is returned.
+func (c *Client) SupportsInstanceOCI() error {
+	if unsupported, err := c.serverSupportsExtensions("instance_oci"); err != nil {
+		return fmt.Errorf("failed to check if server supports 'instance_oci' extension: %w", err)
+	} else if len(unsupported) > 0 {
+		return terminalError{fmt.Errorf("server cannot create OCI containers, required extensions are missing: %v", unsupported)}
+	}
+	return nil
+}
+
+// SupportsNetworkLoadBalancer checks if the necessary API extensions for Network Load Balancers are supported by the server.
+//
+// If network_load_balancer or network_load_balancer_health_check are not supported, a terminalError is returned.
+func (c *Client) SupportsNetworkLoadBalancer() error {
+	if unsupported, err := c.serverSupportsExtensions("network_load_balancer", "network_load_balancer_health_check"); err != nil {
+		return fmt.Errorf("failed to check if server supports network load balancer extensions: %w", err)
+	} else if len(unsupported) > 0 {
+		return terminalError{fmt.Errorf("server cannot create network load balancers, required extensions are missing: %v", unsupported)}
+	}
+	return nil
+}

--- a/internal/incus/lxc_load_balancer_network.go
+++ b/internal/incus/lxc_load_balancer_network.go
@@ -33,10 +33,8 @@ func (l *loadBalancerNetwork) Create(ctx context.Context) ([]string, error) {
 		return nil, terminalError{fmt.Errorf("network load balancer cannot be provisioned as .spec.loadBalancer.ovnNetworkName is not specified")}
 	}
 
-	if unsupported, err := l.lxcClient.serverSupportsExtensions("network_load_balancer", "network_load_balancer_health_check"); err != nil {
-		return nil, fmt.Errorf("failed to check if server supports network load balancer extensions: %w", err)
-	} else if len(unsupported) > 0 {
-		return nil, terminalError{fmt.Errorf("server cannot create network load balancers, required extensions are missing: %v", unsupported)}
+	if err := l.lxcClient.SupportsNetworkLoadBalancer(); err != nil {
+		return nil, err
 	}
 
 	if _, _, err := l.lxcClient.Client.GetNetwork(l.networkName); err != nil {

--- a/internal/incus/lxc_load_balancer_oci.go
+++ b/internal/incus/lxc_load_balancer_oci.go
@@ -34,10 +34,8 @@ func (l *loadBalancerOCI) Create(ctx context.Context) ([]string, error) {
 
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("instance", l.name))
 
-	if unsupported, err := l.lxcClient.serverSupportsExtensions("instance_oci"); err != nil {
-		return nil, fmt.Errorf("failed to check if server supports 'instance_oci' extension: %w", err)
-	} else if len(unsupported) > 0 {
-		return nil, terminalError{fmt.Errorf("server cannot create OCI containers, required extensions are missing: %v", unsupported)}
+	if err := l.lxcClient.SupportsInstanceOCI(); err != nil {
+		return nil, err
 	}
 
 	image := l.spec.Image

--- a/internal/incus/lxc_util_test.go
+++ b/internal/incus/lxc_util_test.go
@@ -5,6 +5,7 @@ import (
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
+
 	. "github.com/onsi/gomega"
 )
 

--- a/test/e2e/shared/overrides.go
+++ b/test/e2e/shared/overrides.go
@@ -1,0 +1,45 @@
+//go:build e2e
+
+package shared
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// OverrideVariables creates a clusterctl config with variable overrides and updates the e2eCtx. It will DeferCleanup() to restore the previous configs after the spec is finished.
+//
+// TODO: this is working around external specs that do not expose the ClusterctlVariables input.
+// Can remove after https://github.com/kubernetes-sigs/cluster-api/pull/11780
+func OverrideVariables(e2eCtx *E2EContext, variables map[string]string) {
+	Expect(e2eCtx.Environment.ClusterctlConfigPath).To(BeAnExistingFile(), "clusterctlConfigPath should be an existing file and point to the clusterctl config file in use by the E2E tests.")
+
+	oldPath := e2eCtx.Environment.ClusterctlConfigPath
+	DeferCleanup(func() {
+		Logf("Restoring config file %s", oldPath)
+		e2eCtx.Environment.ClusterctlConfigPath = oldPath
+	})
+
+	oldConfig, err := os.ReadFile(oldPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	var config map[string]any
+	Expect(yaml.Unmarshal(oldConfig, &config)).To(Succeed())
+	for k, v := range variables {
+		config[k] = v
+	}
+
+	b, err := yaml.Marshal(config)
+	Expect(err).ToNot(HaveOccurred())
+
+	configPath := fmt.Sprintf("%s.%d.yaml", e2eCtx.Environment.ClusterctlConfigPath, GinkgoParallelProcess())
+	Expect(os.WriteFile(configPath, b, 0o600)).To(Succeed())
+
+	Logf("Using config file %s with overrides %v", configPath, variables)
+	e2eCtx.Environment.ClusterctlConfigPath = configPath
+}

--- a/test/e2e/suites/e2e/quick_start_test.go
+++ b/test/e2e/suites/e2e/quick_start_test.go
@@ -7,10 +7,12 @@ import (
 
 	"sigs.k8s.io/cluster-api/test/e2e"
 
+	"github.com/neoaggelos/cluster-api-provider-lxc/internal/incus"
 	"github.com/neoaggelos/cluster-api-provider-lxc/internal/ptr"
 	"github.com/neoaggelos/cluster-api-provider-lxc/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("QuickStart", Label("PRBlocking"), func() {
@@ -41,6 +43,37 @@ var _ = Describe("QuickStart", Label("PRBlocking"), func() {
 				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
 				ControlPlaneMachineCount: ptr.To[int64](3),
 				WorkerMachineCount:       ptr.To[int64](3),
+				PostNamespaceCreated:     e2eCtx.DefaultPostNamespaceCreated(),
+				ControlPlaneWaiters:      e2eCtx.DefaultControlPlaneWaiters(),
+			}
+		})
+	})
+	Context("OCI", func() {
+		BeforeEach(func() {
+			client, err := incus.New(context.TODO(), e2eCtx.Settings.LXCClientOptions)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = client.SupportsInstanceOCI()
+			Expect(err).To(Or(Succeed(), MatchError(incus.IsTerminalError, "IsTerminalError")))
+			if err != nil {
+				Skip("Server does not support OCI instances")
+			}
+
+			shared.OverrideVariables(e2eCtx, map[string]string{
+				"LXC_LOAD_BALANCER_TYPE": "oci",
+			})
+		})
+
+		e2e.QuickStartSpec(context.TODO(), func() e2e.QuickStartSpecInput {
+			return e2e.QuickStartSpecInput{
+				E2EConfig:                e2eCtx.E2EConfig,
+				ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
+				Flavor:                   ptr.To(shared.FlavorDevelopment),
+				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
+				ControlPlaneMachineCount: ptr.To[int64](3),
+				WorkerMachineCount:       ptr.To[int64](0),
 				PostNamespaceCreated:     e2eCtx.DefaultPostNamespaceCreated(),
 				ControlPlaneWaiters:      e2eCtx.DefaultControlPlaneWaiters(),
 			}


### PR DESCRIPTION
## Summary

- Add `shared.OverrideVariables()`, which can override cluster template variables on each spec.
- Add `QuickStart OCI` e2e test, which checks if server supports OCI instances. Skips the test if not, otherwise runs the quick start with 3 control plane nodes and an OCI load balancer.

