### PR TITLE
Style improvements in e2e tests

### DIFF
--- a/test/e2e/shared/overrides.go
+++ b/test/e2e/shared/overrides.go
@@ -16,7 +16,7 @@ import (
 //
 // TODO: this is working around external specs that do not expose the ClusterctlVariables input.
 // Can remove after https://github.com/kubernetes-sigs/cluster-api/pull/11780
-func OverrideVariables(e2eCtx *E2EContext, variables map[string]string) {
+func (e2eCtx *E2EContext) OverrideVariables(variables map[string]string) {
 	Expect(e2eCtx.Environment.ClusterctlConfigPath).To(BeAnExistingFile(), "clusterctlConfigPath should be an existing file and point to the clusterctl config file in use by the E2E tests.")
 
 	oldPath := e2eCtx.Environment.ClusterctlConfigPath

--- a/test/e2e/shared/setup.go
+++ b/test/e2e/shared/setup.go
@@ -13,6 +13,7 @@ import (
 	addonsv1 "sigs.k8s.io/cluster-api/exp/addons/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/gomega"
@@ -84,15 +85,13 @@ func FixupWorkloadCluster(e2eCtx *E2EContext, name string, namespace string) {
 	clusterName := types.NamespacedName{Name: name, Namespace: namespace}
 	cluster := &clusterv1.Cluster{}
 
-	e2e.Byf("Fetch workload cluster %v", clusterName)
+	e2e.Byf("Fetching workload cluster %v", clusterName)
 	Expect(clusterClient.Get(context.TODO(), clusterName, cluster)).To(Succeed(), "Failed to retrieve workload cluster")
 
-	e2e.Byf("Patch workload cluster %v", clusterName)
+	e2e.Byf("Labeling workload cluster %v with cni=cni-resources", clusterName)
 	framework.PatchClusterLabel(context.TODO(), framework.PatchClusterLabelInput{
 		ClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
 		Cluster:      cluster,
-		Labels: map[string]string{
-			"cni": "cni-resources",
-		},
+		Labels:       util.MergeMap(map[string]string{"cni": "cni-resources"}, cluster.Labels),
 	})
 }

--- a/test/e2e/suites/e2e/quick_start_test.go
+++ b/test/e2e/suites/e2e/quick_start_test.go
@@ -59,7 +59,7 @@ var _ = Describe("QuickStart", Label("PRBlocking"), func() {
 				Skip("Server does not support OCI instances")
 			}
 
-			shared.OverrideVariables(e2eCtx, map[string]string{
+			e2eCtx.OverrideVariables(map[string]string{
 				"LXC_LOAD_BALANCER_TYPE": "oci",
 			})
 		})


### PR DESCRIPTION
- prefer e2eCtx.OverrideVariables() style
- do not overwrite cluster labels from template
