### PR TITLE
use Cluster name instead of LXCCluster name to annotate objects

### DIFF
--- a/internal/controller/lxccluster/controller.go
+++ b/internal/controller/lxccluster/controller.go
@@ -129,7 +129,7 @@ func (r *LXCClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Handle non-deleted clusters
-	return ctrl.Result{}, r.reconcileNormal(ctx, lxcCluster, lxcClient)
+	return ctrl.Result{}, r.reconcileNormal(ctx, cluster, lxcCluster, lxcClient)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/lxccluster/controller_delete.go
+++ b/internal/controller/lxccluster/controller_delete.go
@@ -35,7 +35,7 @@ func (r *LXCClusterReconciler) reconcileDelete(ctx context.Context, cluster *clu
 
 	// Delete the container hosting the load balancer
 	log.FromContext(ctx).Info("Deleting load balancer")
-	if err := lxcClient.LoadBalancerManagerForCluster(lxcCluster).Delete(ctx); err != nil {
+	if err := lxcClient.LoadBalancerManagerForCluster(cluster, lxcCluster).Delete(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to delete the load balancer instance: %w", err)
 	}
 

--- a/internal/controller/lxccluster/controller_normal.go
+++ b/internal/controller/lxccluster/controller_normal.go
@@ -14,7 +14,7 @@ import (
 	"github.com/neoaggelos/cluster-api-provider-lxc/internal/profile"
 )
 
-func (r *LXCClusterReconciler) reconcileNormal(ctx context.Context, lxcCluster *infrav1.LXCCluster, lxcClient *incus.Client) error {
+func (r *LXCClusterReconciler) reconcileNormal(ctx context.Context, cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluster, lxcClient *incus.Client) error {
 	// Create the default kubeadm profile for LXC containers
 	profileName := lxcCluster.GetProfileName()
 	if lxcCluster.Spec.SkipDefaultKubeadmProfile {
@@ -41,7 +41,7 @@ func (r *LXCClusterReconciler) reconcileNormal(ctx context.Context, lxcCluster *
 
 	// Create the container hosting the load balancer.
 	log.FromContext(ctx).Info("Creating load balancer")
-	lbIPs, err := lxcClient.LoadBalancerManagerForCluster(lxcCluster).Create(ctx)
+	lbIPs, err := lxcClient.LoadBalancerManagerForCluster(cluster, lxcCluster).Create(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to provision load balancer")
 		if incus.IsTerminalError(err) {

--- a/internal/controller/lxcmachine/controller_delete.go
+++ b/internal/controller/lxcmachine/controller_delete.go
@@ -38,7 +38,7 @@ func (r *LXCMachineReconciler) reconcileDelete(ctx context.Context, cluster *clu
 	// If the deleted machine is a control-plane node, remove it from the load balancer configuration (unless the cluster is getting deleted)
 	if util.IsControlPlaneMachine(machine) && cluster.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.FromContext(ctx).Info("Reconfigure load balancer after removing control plane machine")
-		if err := lxcClient.LoadBalancerManagerForCluster(lxcCluster).Reconfigure(ctx); err != nil {
+		if err := lxcClient.LoadBalancerManagerForCluster(cluster, lxcCluster).Reconfigure(ctx); err != nil {
 			return fmt.Errorf("failed to reconfigure load balancer after removing control plane node: %w", err)
 		}
 	}

--- a/internal/controller/lxcmachine/controller_normal.go
+++ b/internal/controller/lxcmachine/controller_normal.go
@@ -97,7 +97,7 @@ func (r *LXCMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 		return ctrl.Result{}, fmt.Errorf("failed to patch LXCMachine: %w", err)
 	}
 
-	addresses, err := lxcClient.CreateInstance(ctx, machine, lxcMachine, lxcCluster, cloudInit)
+	addresses, err := lxcClient.CreateInstance(ctx, machine, lxcMachine, cluster, lxcCluster, cloudInit)
 	if err != nil {
 		if incus.IsTerminalError(err) {
 			log.FromContext(ctx).Error(err, "Fatal error while creating instance")
@@ -112,7 +112,7 @@ func (r *LXCMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 
 	// update load balancer
 	if util.IsControlPlaneMachine(machine) && !lxcMachine.Status.LoadBalancerConfigured {
-		if err := lxcClient.LoadBalancerManagerForCluster(lxcCluster).Reconfigure(ctx); err != nil {
+		if err := lxcClient.LoadBalancerManagerForCluster(cluster, lxcCluster).Reconfigure(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to update loadbalancer configuration: %w", err)
 		}
 		lxcMachine.Status.LoadBalancerConfigured = true

--- a/internal/incus/lxc_instance_create.go
+++ b/internal/incus/lxc_instance_create.go
@@ -16,7 +16,7 @@ import (
 )
 
 // CreateInstance creates the LXC instance based on configuration from the machine.
-func (c *Client) CreateInstance(ctx context.Context, machine *clusterv1.Machine, lxcMachine *infrav1.LXCMachine, lxcCluster *infrav1.LXCCluster, cloudInit string) ([]string, error) {
+func (c *Client) CreateInstance(ctx context.Context, machine *clusterv1.Machine, lxcMachine *infrav1.LXCMachine, cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluster, cloudInit string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(ctx, instanceCreateTimeout)
 	defer cancel()
 
@@ -96,8 +96,8 @@ func (c *Client) CreateInstance(ctx context.Context, machine *clusterv1.Machine,
 		InstancePut: api.InstancePut{
 			Profiles: profiles,
 			Config: map[string]string{
-				configClusterNameKey:      lxcCluster.Name,
-				configClusterNamespaceKey: lxcCluster.Namespace,
+				configClusterNameKey:      cluster.Name,
+				configClusterNamespaceKey: cluster.Namespace,
 				configInstanceRoleKey:     role,
 				configCloudInitKey:        cloudInit,
 			},

--- a/internal/incus/lxc_load_balancer.go
+++ b/internal/incus/lxc_load_balancer.go
@@ -3,6 +3,8 @@ package incus
 import (
 	"context"
 
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
 	infrav1 "github.com/neoaggelos/cluster-api-provider-lxc/api/v1alpha2"
 )
 
@@ -22,13 +24,13 @@ type LoadBalancerManager interface {
 }
 
 // LoadBalancerManagerForCluster returns the proper LoadBalancerManager based on the lxcCluster spec.
-func (c *Client) LoadBalancerManagerForCluster(lxcCluster *infrav1.LXCCluster) LoadBalancerManager {
+func (c *Client) LoadBalancerManagerForCluster(cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluster) LoadBalancerManager {
 	switch {
 	case lxcCluster.Spec.LoadBalancer.LXC != nil:
 		return &loadBalancerLXC{
 			lxcClient:        c,
-			clusterName:      lxcCluster.Name,
-			clusterNamespace: lxcCluster.Namespace,
+			clusterName:      cluster.Name,
+			clusterNamespace: cluster.Namespace,
 
 			name: lxcCluster.GetLoadBalancerInstanceName(),
 			spec: lxcCluster.Spec.LoadBalancer.LXC.InstanceSpec,
@@ -36,8 +38,8 @@ func (c *Client) LoadBalancerManagerForCluster(lxcCluster *infrav1.LXCCluster) L
 	case lxcCluster.Spec.LoadBalancer.OCI != nil:
 		return &loadBalancerOCI{
 			lxcClient:        c,
-			clusterName:      lxcCluster.Name,
-			clusterNamespace: lxcCluster.Namespace,
+			clusterName:      cluster.Name,
+			clusterNamespace: cluster.Namespace,
 
 			name: lxcCluster.GetLoadBalancerInstanceName(),
 			spec: lxcCluster.Spec.LoadBalancer.OCI.InstanceSpec,
@@ -45,8 +47,8 @@ func (c *Client) LoadBalancerManagerForCluster(lxcCluster *infrav1.LXCCluster) L
 	case lxcCluster.Spec.LoadBalancer.OVN != nil:
 		return &loadBalancerNetwork{
 			lxcClient:        c,
-			clusterName:      lxcCluster.Name,
-			clusterNamespace: lxcCluster.Namespace,
+			clusterName:      cluster.Name,
+			clusterNamespace: cluster.Namespace,
 
 			networkName:   lxcCluster.Spec.LoadBalancer.OVN.NetworkName,
 			listenAddress: lxcCluster.Spec.ControlPlaneEndpoint.Host,
@@ -54,8 +56,8 @@ func (c *Client) LoadBalancerManagerForCluster(lxcCluster *infrav1.LXCCluster) L
 	case lxcCluster.Spec.LoadBalancer.External != nil:
 		return &loadBalancerExternal{
 			lxcClient:        c,
-			clusterName:      lxcCluster.Name,
-			clusterNamespace: lxcCluster.Namespace,
+			clusterName:      cluster.Name,
+			clusterNamespace: cluster.Namespace,
 
 			address: lxcCluster.Spec.ControlPlaneEndpoint.Host,
 		}
@@ -64,8 +66,8 @@ func (c *Client) LoadBalancerManagerForCluster(lxcCluster *infrav1.LXCCluster) L
 		// If only Go had enums.
 		return &loadBalancerExternal{
 			lxcClient:        c,
-			clusterName:      lxcCluster.Name,
-			clusterNamespace: lxcCluster.Namespace,
+			clusterName:      cluster.Name,
+			clusterNamespace: cluster.Namespace,
 
 			address: lxcCluster.Spec.ControlPlaneEndpoint.Host,
 		}


### PR DESCRIPTION
### Summary

In existing clusters, `LXCCluster.Name == Cluster.Name`. However, this is not the case when using a ClusterClass, as the `LXCCluster.Name` will be `Cluster.Name + <random-suffix>`.

Fix existing code paths to consistently use the `Cluster.Name` instead. This is not considered a breaking change now, as we do not (yet) use cluster topology.

