### PR TITLE
Drop `cd docs/book && make test` from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,3 @@ jobs:
 
       - name: make test
         run: make test
-
-      - name: make test docs
-        working-directory: docs/book
-        run: make test


### PR DESCRIPTION
### Summary

Remove the `make test` step from the documentation, as it does not perform anything useful for us. It will eventually be replaced by proper testing (e.g. making sure that no links are 404