### PR TITLE
Add e2e test with ubuntu flavor (install kubeadm during cloud-init)

### DIFF
--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -68,6 +68,7 @@ providers:
     - sourcePath: "../data/shared/v1beta1_provider/metadata.yaml"
     # add cluster templates
     - sourcePath: "../../../templates/cluster-template-development.yaml"
+    - sourcePath: "../../../templates/cluster-template-ubuntu.yaml"
     replacements:
     - old: ghcr.io/neoaggelos/cluster-api-provider-lxc:latest
       new: ghcr.io/neoaggelos/cluster-api-provider-lxc:e2e

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -41,6 +41,7 @@ const (
 	LXCSecretName = "LXC_SECRET_NAME"
 
 	FlavorDevelopment = "development"
+	FlavorUbuntu      = "ubuntu"
 
 	FlavorDefault = FlavorDevelopment
 )

--- a/test/e2e/suites/e2e/quick_start_test.go
+++ b/test/e2e/suites/e2e/quick_start_test.go
@@ -48,6 +48,27 @@ var _ = Describe("QuickStart", Label("PRBlocking"), func() {
 			}
 		})
 	})
+	Context("Ubuntu", func() {
+		BeforeEach(func() {
+			e2eCtx.OverrideVariables(map[string]string{
+				"LXC_IMAGE_NAME": "ubuntu:24.04",
+			})
+		})
+		e2e.QuickStartSpec(context.TODO(), func() e2e.QuickStartSpecInput {
+			return e2e.QuickStartSpecInput{
+				E2EConfig:                e2eCtx.E2EConfig,
+				ClusterctlConfigPath:     e2eCtx.Environment.ClusterctlConfigPath,
+				BootstrapClusterProxy:    e2eCtx.Environment.BootstrapClusterProxy,
+				ArtifactFolder:           e2eCtx.Settings.ArtifactFolder,
+				Flavor:                   ptr.To(shared.FlavorUbuntu),
+				SkipCleanup:              e2eCtx.Settings.SkipCleanup,
+				ControlPlaneMachineCount: ptr.To[int64](1),
+				WorkerMachineCount:       ptr.To[int64](1),
+				PostNamespaceCreated:     e2eCtx.DefaultPostNamespaceCreated(),
+				ControlPlaneWaiters:      e2eCtx.DefaultControlPlaneWaiters(),
+			}
+		})
+	})
 	Context("OCI", func() {
 		BeforeEach(func() {
 			client, err := incus.New(context.TODO(), e2eCtx.Settings.LXCClientOptions)


### PR DESCRIPTION
### Summary

Add a `QuickStart Ubuntu` e2e test, using the ubuntu flavor.

Kubeadm is installed by cloud-init prior to initializing the node, running with a stock Ubuntu 24.04 image