### PR TITLE
Consider BootstrapSucceeded condition when setting LXCMachine status

### DIFF
--- a/internal/controller/lxcmachine/controller_util.go
+++ b/internal/controller/lxcmachine/controller_util.go
@@ -17,6 +17,7 @@ import (
 func patchLXCMachine(ctx context.Context, patchHelper *patch.Helper, lxcMachine *infrav1.LXCMachine) error {
 	infraConditions := []clusterv1.ConditionType{
 		infrav1.InstanceProvisionedCondition,
+		infrav1.BootstrapSucceededCondition,
 	}
 	hasInfraConditionError := false
 	for _, condition := range lxcMachine.GetConditions() {


### PR DESCRIPTION
### Summary

Previously, the Ready condition on LXCMachine objects was set to true only based on the InstanceProvisioned, which ignored the cloud-init status of the node.

This could result in LXCMachine's where cloud-init failed but the machine reported a healthy status.