### PR TITLE
Pull kubeadm images for target base image version

### DIFF
--- a/hack/scripts/images/stages/50-install-kubeadm.sh
+++ b/hack/scripts/images/stages/50-install-kubeadm.sh
@@ -80,4 +80,4 @@ fi
 systemctl enable kubelet.service
 
 # pull images
-kubeadm config images pull
+kubeadm config images pull --kubernetes-version "${KUBERNETES_VERSION}"


### PR DESCRIPTION
### Summary

The default behavior of `kubeadm config images pull` is to pull the Kubernetes images for the latest patch-level version of the current release.

### Notes

Previously, this resulted in building a base image for `kubeadm/v1.32.0`, which pulled images for a newer release (e.g. `v1.32.1`). Those images were unused, and also caused delays during cluster provisioning as the right image versions had to be pulled on each node. 