### PR TITLE
fix default diagnostics-address flag value

### DIFF
--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,7 +1,7 @@
 # This patch adds the args to allow exposing the metrics endpoint using HTTPS
 - op: add
   path: /spec/template/spec/containers/0/args/0
-  value: --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=8443}
+  value: --diagnostics-address=${CAPI_DIAGNOSTICS_ADDRESS:=:8443}
 - op: add
   path: /spec/template/spec/containers/0/args/0
   value: --insecure-diagnostics=${CAPI_INSECURE_DIAGNOSTICS:=false}


### PR DESCRIPTION
### Summary

Fix default value for CAPI_DIAGNOSTICS_ADDRESS (must be `:8443` instead of `8443`)

Has been fixed manually for v0.3.0 release