### PR TITLE
Add cluster-autoscaler e2e spec

### DIFF
--- a/templates/cluster-template-autoscaler.yaml
+++ b/templates/cluster-template-autoscaler.yaml
@@ -1,0 +1,61 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ${POD_CIDR:=[10.244.0.0/16]}
+    services:
+      cidrBlocks: ${SERVICE_CIDR:=[10.96.0.0/12]}
+    serviceDomain: cluster.local
+  topology:
+    class: lxc-default
+    version: ${KUBERNETES_VERSION}
+    controlPlane:
+      replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
+    variables:
+    # Cluster configuration
+    - name: secretRef
+      value: ${LXC_SECRET_NAME}
+    - name: loadBalancer
+      value:
+        ${LOAD_BALANCER}
+
+        ## LOAD_BALANCER can be one of:
+        # lxc: {profiles: [default], flavor: c1-m1}
+        # oci: {profiles: [default], flavor: c1-m1}
+        # kube-vip: {host: 10.0.42.1}
+        # ovn: {host: 10.100.42.1, networkName: default}
+
+    # Control plane instance configuration
+    - name: instance
+      value:
+        type: ${CONTROL_PLANE_MACHINE_TYPE:=container}
+        flavor: ${CONTROL_PLANE_MACHINE_FLAVOR:=c2-m4}
+        profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+        image: ${LXC_IMAGE_NAME:=""}
+        installKubeadm: ${INSTALL_KUBEADM:=false}
+
+    # CNI
+    - name: deployKubeFlannel
+      value: ${DEPLOY_KUBE_FLANNEL:=false}
+
+    workers:
+      machineDeployments:
+      - class: default-worker
+        name: md-0
+        metadata:
+          annotations:
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "1"
+            cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
+        variables:
+          overrides:
+          # Worker instance configuration
+          - name: instance
+            value:
+              type: ${WORKER_MACHINE_TYPE:=container}
+              flavor: ${WORKER_MACHINE_FLAVOR:=c2-m4}
+              profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+              image: ${LXC_IMAGE_NAME:=""}
+              installKubeadm: ${INSTALL_KUBEADM:=false}

--- a/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
+++ b/test/e2e/data/autoscaler/autoscaler-to-management-workload.yaml
@@ -1,0 +1,221 @@
+# Sourced from: https://github.com/kubernetes-sigs/cluster-api/blob/v1.9.4/test/e2e/data/autoscaler/autoscaler-to-workload-workload.yaml
+# Modifications to deploy the autoscaler on the workload cluster:
+# - Replace 'cluster-autoscaler-system' with '${CLUSTER_NAMESPACE}'.
+# - Add 'kubeconfig-workload-cluster' volume and volumeMount with the workload cluster kubeconfig. The kubeconfig is sourced from the ${CLUSTER_NAME}-kubeconfig secret.
+# - Add '--kubeconfig=/workload-cluster/kubeconfig' argument to cluster-autoscaler, so that it connects to the workload cluster.
+
+# This yaml deploys the autoscaler on a management cluster and configures it to match
+# against the corresponding Cluster API workload cluster.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${CLUSTER_NAMESPACE}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
+---
+# Specify kubeconfig for management cluster
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubeconfig-management-cluster
+  namespace: ${CLUSTER_NAMESPACE}
+stringData:
+  kubeconfig: |
+    apiVersion: v1
+    kind: Config
+    clusters:
+    - name: management-cluster
+      cluster:
+        certificate-authority-data: ${MANAGEMENT_CLUSTER_CA}
+        server: ${MANAGEMENT_CLUSTER_ADDRESS}
+    contexts:
+    - name: management-context
+      context:
+        cluster: management-cluster
+        namespace: ${CLUSTER_NAMESPACE}
+        user: cluster-autoscaler-sa
+    current-context: management-context
+    users:
+    - name: cluster-autoscaler-sa
+      user:
+        token: "${MANAGEMENT_CLUSTER_TOKEN}"
+---
+# Defines the service used by the cluster autoscaler and gives it
+# RBAC permissions to look at all the workloads running in this cluster.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-autoscaler
+  namespace: ${CLUSTER_NAMESPACE}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-workload
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-autoscaler-workload
+subjects:
+  - kind: ServiceAccount
+    name: cluster-autoscaler
+    namespace: ${CLUSTER_NAMESPACE}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cluster-autoscaler-workload
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csinodes
+      - storageclasses
+      - csidrivers
+      - csistoragecapacities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - update
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-autoscaler
+  namespace: ${CLUSTER_NAMESPACE}
+  labels:
+    app: cluster-autoscaler
+spec:
+  selector:
+    matchLabels:
+      app: cluster-autoscaler
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cluster-autoscaler
+    spec:
+      containers:
+        - image: registry.k8s.io/autoscaling/cluster-autoscaler:${AUTOSCALER_VERSION}
+          name: cluster-autoscaler
+          command:
+            - /cluster-autoscaler
+          args:
+            - --cloud-provider=clusterapi
+            # Specify kubeconfig for management cluster
+            - --cloud-config=/management-cluster/kubeconfig
+            # Specify kubeconfig for workload cluster
+            - --kubeconfig=/workload-cluster/kubeconfig
+            # Limit cluster autoscaler to only match against resources belonging to a single Cluster API cluster
+            - --node-group-auto-discovery=clusterapi:namespace=${CLUSTER_NAMESPACE},clusterName=${CLUSTER_NAME}
+            # Set a short scale down unneeded time, so we don't have to wait too long during e2e testing
+            - --scale-down-unneeded-time=1m
+            #  Set a short scale down delay after add time, so we don't have to wait too long during e2e testing
+            - --scale-down-delay-after-add=1m
+            # Set a short scale down delay after delete time, so we don't have to wait too long during e2e testing
+            - --scale-down-delay-after-delete=1m
+            # Set a short scale down delay after failure time, so we don't have to wait too long during e2e testing
+            - --scale-down-delay-after-failure=1m
+            # Set a max nodes limit as safeguard so that the test does not scale up unbounded.
+            # Note: The E2E test should only go up to 4 (assuming it starts with a min node group size of 2).
+            # Using 6 for additional some buffer and to allow different starting min node group sizes.
+            - --max-nodes-total=6
+          volumeMounts:
+            - name: kubeconfig-management-cluster
+              mountPath: /management-cluster
+              readOnly: true
+            - name: kubeconfig-workload-cluster
+              mountPath: /workload-cluster
+              readOnly: true
+      serviceAccountName: cluster-autoscaler
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: kubeconfig-management-cluster
+          secret:
+            secretName: kubeconfig-management-cluster
+            optional: false
+        - name: kubeconfig-workload-cluster
+          secret:
+            secretName: ${CLUSTER_NAME}-kubeconfig
+            items:
+              - key: value
+                path: kubeconfig
+            optional: false

--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -69,6 +69,7 @@ providers:
     - sourcePath: "../../../templates/clusterclass-lxc-default.yaml"
     - sourcePath: "../../../templates/cluster-template.yaml"
     - sourcePath: "../../../templates/cluster-template-development.yaml"
+    - sourcePath: "../../../templates/cluster-template-autoscaler.yaml"
     replacements:
     - old: ghcr.io/neoaggelos/cluster-api-provider-lxc:latest
       new: ghcr.io/neoaggelos/cluster-api-provider-lxc:e2e
@@ -98,9 +99,14 @@ variables:
   WORKER_MACHINE_TYPE: container
   DEPLOY_KUBE_FLANNEL: "false"
 
+  # Conformance tests configuration
   KUBETEST_CONFIGURATION: ../../data/kubetest/conformance.yaml
   KUBETEST_GINKGO_NODES: "5"
 
+  # Autoscaler tests configuration
+  AUTOSCALER_WORKLOAD: ../../data/autoscaler/autoscaler-to-management-workload.yaml
+
+  # ClusterAPI providers configuration
   CLUSTER_TOPOLOGY: "true"
   CAPI_DIAGNOSTICS_ADDRESS: ":8080"
   CAPI_INSECURE_DIAGNOSTICS: "true"
@@ -124,3 +130,5 @@ intervals:
 
   default/wait-deployment-available: ["1m", "5s"]
   default/wait-machine-deleted: ["5m", "10s"]
+
+  default/wait-autoscaler: ["5m", "10s"]

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -42,6 +42,7 @@ const (
 
 	FlavorDefault     = ""
 	FlavorDevelopment = "development"
+	FlavorAutoscaler  = "autoscaler"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/suites/e2e/autoscaler_test.go
+++ b/test/e2e/suites/e2e/autoscaler_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+
+	"sigs.k8s.io/cluster-api/test/e2e"
+
+	"github.com/neoaggelos/cluster-api-provider-lxc/internal/ptr"
+	"github.com/neoaggelos/cluster-api-provider-lxc/test/e2e/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Autoscaler", Label("full"), func() {
+	// TODO: investigate why ScaleToAndFromZero is failing to scale back up from zero
+	e2e.AutoscalerSpec(context.TODO(), func() e2e.AutoscalerSpecInput {
+		return e2e.AutoscalerSpecInput{
+			E2EConfig:             e2eCtx.E2EConfig,
+			ClusterctlConfigPath:  e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy: e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:        e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:           e2eCtx.Settings.SkipCleanup,
+			PostNamespaceCreated:  e2eCtx.DefaultPostNamespaceCreated(),
+			ControlPlaneWaiters:   e2eCtx.DefaultControlPlaneWaiters(),
+
+			Flavor: ptr.To(shared.FlavorAutoscaler),
+
+			InfrastructureProvider:            ptr.To("lxc"),
+			InfrastructureMachineTemplateKind: "lxcmachinetemplates",
+			AutoscalerVersion:                 "v1.31.1",
+			InstallOnManagementCluster:        true,
+		}
+	})
+})


### PR DESCRIPTION
### Summary

Add autoscaler cluster template, cluster autoscaler e2e test and configs

#### Example run

```
------------------------------
Autoscaler Should create a workload cluster [full]
/home/ubuntu/go/pkg/mod/sigs.k8s.io/cluster-api/test@v1.9.4/e2e/autoscaler.go:114
  > Enter [BeforeEach] Autoscaler @ 02/15/25 12:34:45.132
  STEP: Creating a namespace for hosting the "autoscaler" test spec @ 02/15/25 12:34:45.132
  INFO: Creating namespace autoscaler-yy7pll
  INFO: Creating event watcher for namespace "autoscaler-yy7pll"
  INFO: Calling postNamespaceCreated for namespace autoscaler-yy7pll
  STEP: Creating resource secret/lxc-credentials on namespace autoscaler-yy7pll @ 02/15/25 12:34:45.139
  STEP: Creating resource configmap/cni-resources on namespace autoscaler-yy7pll @ 02/15/25 12:34:45.152
  STEP: Creating resource clusterresourceset/cni-resource-set on namespace autoscaler-yy7pll @ 02/15/25 12:34:45.162
  < Exit [BeforeEach] Autoscaler @ 02/15/25 12:34:45.173 (42ms)
  > Enter [It] Should create a workload cluster @ 02/15/25 12:34:45.173
  STEP: Creating a workload cluster @ 02/15/25 12:34:45.173
  INFO: Creating the workload cluster with name "autoscaler-2oum8u" using the "autoscaler" template (Kubernetes v1.32.2, 1 control-plane machines, (unset) worker machines)
  INFO: Getting the cluster template yaml
  INFO: clusterctl config cluster autoscaler-2oum8u --infrastructure lxc --kubernetes-version v1.32.2 --control-plane-machine-count 1 --flavor autoscaler
  INFO: Creating the workload cluster with name "autoscaler-2oum8u" from the provided yaml
  INFO: Applying the cluster template yaml of cluster autoscaler-yy7pll/autoscaler-2oum8u
  INFO: Waiting for the cluster infrastructure of cluster autoscaler-yy7pll/autoscaler-2oum8u to be provisioned
  STEP: Waiting for cluster to enter the provisioned phase @ 02/15/25 12:34:45.565
  INFO: Waiting for control plane of cluster autoscaler-yy7pll/autoscaler-2oum8u to be initialized
  STEP: Fetching workload cluster autoscaler-yy7pll/autoscaler-2oum8u @ 02/15/25 12:34:55.574
  STEP: Labeling workload cluster autoscaler-yy7pll/autoscaler-2oum8u with cni=cni-resources @ 02/15/25 12:34:55.577
  INFO: Patching the label to the cluster
  INFO: Waiting for the first control plane machine managed by autoscaler-yy7pll/autoscaler-2oum8u-cnzh2 to be provisioned
  STEP: Waiting for one control plane node to exist @ 02/15/25 12:34:55.606
  INFO: Waiting for control plane of cluster autoscaler-yy7pll/autoscaler-2oum8u to be ready
  INFO: Waiting for control plane autoscaler-yy7pll/autoscaler-2oum8u-cnzh2 to be ready (implies underlying nodes to be ready as well)
  STEP: Waiting for the control plane to be ready @ 02/15/25 12:35:25.626
  STEP: Checking all the control plane machines are in the expected failure domains @ 02/15/25 12:35:25.629
  INFO: Waiting for the machine deployments of cluster autoscaler-yy7pll/autoscaler-2oum8u to be provisioned
  STEP: Waiting for the workload nodes to exist @ 02/15/25 12:35:25.633
  STEP: Checking all the machines controlled by autoscaler-2oum8u-md-0-jjr6t are in the "<None>" failure domain @ 02/15/25 12:35:45.642
  INFO: Waiting for the machine pools of cluster autoscaler-yy7pll/autoscaler-2oum8u to be provisioned
  STEP: Installing the autoscaler on the workload cluster @ 02/15/25 12:35:45.649
  STEP: Creating the autoscaler deployment in the workload cluster @ 02/15/25 12:35:45.649
  STEP: Wait for the autoscaler deployment and collect logs @ 02/15/25 12:35:45.738
  STEP: Waiting for deployment autoscaler-yy7pll/cluster-autoscaler to be available @ 02/15/25 12:35:45.751
  STEP: Creating workload that forces the system to scale up @ 02/15/25 12:35:55.865
  STEP: Create a scale up deployment with resource requests to force scale up @ 02/15/25 12:35:55.865
  INFO: Creating log watcher for controller autoscaler-yy7pll/cluster-autoscaler, pod cluster-autoscaler-9b5b75fdb-jj5gd, container cluster-autoscaler
  STEP: Create scale up deployment @ 02/15/25 12:35:55.87
  STEP: Wait for the scale up deployment to become ready (this implies machines to be created) @ 02/15/25 12:35:55.89
  STEP: Waiting for deployment default/scale-up to be available @ 02/15/25 12:35:55.89
  STEP: Checking the MachineDeployment is scaled up @ 02/15/25 12:36:35.904
  STEP: Disabling the autoscaler @ 02/15/25 12:36:35.908
  INFO: Dropping the cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size and cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size annotations from the MachineDeployments in ClusterTopology
  INFO: Wait for the annotations to be dropped from the MachineDeployments
  STEP: Checking we can manually scale up the MachineDeployment @ 02/15/25 12:36:36.008
  INFO: Scaling machine deployment topology md-0 to 3 replicas
  INFO: Waiting for correct number of replicas to exist
  STEP: Checking enabling autoscaler will scale down the MachineDeployment to correct size @ 02/15/25 12:36:56.117
  INFO: Add the cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size and cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size annotations to the MachineDeployments in ClusterTopology
  INFO: Wait for the annotations to applied on the MachineDeployments
  STEP: Checking the MachineDeployment is scaled down @ 02/15/25 12:37:06.143
  STEP: Disabling the autoscaler for MachineDeployments to test MachinePools @ 02/15/25 12:38:26.171
  INFO: Dropping the cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size and cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size annotations from the MachineDeployments in ClusterTopology
  INFO: Wait for the annotations to be dropped from the MachineDeployments
  STEP: Deleting the MachineDeployment scale up deployment @ 02/15/25 12:38:26.265
  STEP: Retrieving the scale up deployment @ 02/15/25 12:38:26.265
  STEP: Deleting the scale up deployment @ 02/15/25 12:38:26.272
  STEP: Waiting for the scale up deployment to be deleted @ 02/15/25 12:38:26.278
  STEP: PASSED! @ 02/15/25 12:38:26.281
  < Exit [It] Should create a workload cluster @ 02/15/25 12:38:26.281 (3m41.107s)
  > Enter [AfterEach] Autoscaler @ 02/15/25 12:38:26.281
  STEP: Dumping logs from the "autoscaler-2oum8u" workload cluster @ 02/15/25 12:38:26.281
  [2025-02-15T12:38:26+02:00] Collecting logs for machine "autoscaler-2oum8u-cnzh2-cm6vf" and storing them in "/home/ubuntu/Documents/projects/cluster-api-provider-lxc/_artifacts/clusters/autoscaler-2oum8u/machines/autoscaler-2oum8u-cnzh2-cm6vf"
  [2025-02-15T12:38:27+02:00] Collecting logs for machine "autoscaler-2oum8u-md-0-jjr6t-v2lb6-6b7vx" and storing them in "/home/ubuntu/Documents/projects/cluster-api-provider-lxc/_artifacts/clusters/autoscaler-2oum8u/machines/autoscaler-2oum8u-md-0-jjr6t-v2lb6-6b7vx"
  [2025-02-15T12:38:28+02:00] Collecting logs for machine "autoscaler-2oum8u-md-0-jjr6t-v2lb6-fdd8c" and storing them in "/home/ubuntu/Documents/projects/cluster-api-provider-lxc/_artifacts/clusters/autoscaler-2oum8u/machines/autoscaler-2oum8u-md-0-jjr6t-v2lb6-fdd8c"
  [2025-02-15T12:38:30+02:00] Collecting logs for cluster "autoscaler-yy7pll/autoscaler-2oum8u" and storing them in "/home/ubuntu/Documents/projects/cluster-api-provider-lxc/_artifacts/clusters/autoscaler-2oum8u/infrastructure"
  STEP: Dumping all the Cluster API resources in the "autoscaler-yy7pll" namespace @ 02/15/25 12:38:30.401
  STEP: Dumping Pods and Nodes of Cluster autoscaler-yy7pll/autoscaler-2oum8u @ 02/15/25 12:38:30.482
  STEP: Deleting cluster autoscaler-yy7pll/autoscaler-2oum8u @ 02/15/25 12:38:30.512
  STEP: Deleting cluster autoscaler-yy7pll/autoscaler-2oum8u @ 02/15/25 12:38:30.515
  INFO: Waiting for the Cluster autoscaler-yy7pll/autoscaler-2oum8u to be deleted
  STEP: Waiting for cluster autoscaler-yy7pll/autoscaler-2oum8u to be deleted @ 02/15/25 12:38:30.529
  STEP: Deleting namespace used for hosting the "autoscaler" test spec @ 02/15/25 12:38:40.533
  INFO: Deleting namespace autoscaler-yy7pll
  < Exit [AfterEach] Autoscaler @ 02/15/25 12:38:40.547 (14.266s)
• [235.415 seconds]
```