### PR TITLE
Fixes in LXCMachineReconciler

### DIFF
--- a/internal/incus/lxc_instance_create.go
+++ b/internal/incus/lxc_instance_create.go
@@ -111,12 +111,12 @@ func (c *Client) CreateInstance(ctx context.Context, machine *clusterv1.Machine,
 	}
 
 	if err := c.ensureInstanceRunning(ctx, name); err != nil {
-		return nil, fmt.Errorf("failed to ensure loadbalancer instance is running: %w", err)
+		return nil, fmt.Errorf("failed to ensure instance is running: %w", err)
 	}
 
 	addrs, err := c.waitForInstanceAddress(ctx, name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get loadbalancer instance address: %w", err)
+		return nil, fmt.Errorf("failed to get instance address: %w", err)
 	}
 	return addrs, nil
 }

--- a/internal/incus/lxc_util.go
+++ b/internal/incus/lxc_util.go
@@ -221,7 +221,7 @@ func (c *Client) serverSupportsExtensions(extensions ...string) ([]string, error
 }
 
 // List existing server operations to find if any CreateInstance operations are pending for the target instance name.
-// If anything fails, it will return the error that occured.
+// If anything fails, it will return the error that occurred.
 // If any is active, it will return a waitable incus.Operation object.
 // If no operations are active, it will return nil.
 //

--- a/internal/incus/lxc_util.go
+++ b/internal/incus/lxc_util.go
@@ -107,7 +107,16 @@ func (c *Client) createInstanceIfNotExists(ctx context.Context, instance api.Ins
 	}
 
 	log.FromContext(ctx).V(2).Info("Creating instance")
-	return c.wait(ctx, "CreateInstance", func() (incus.Operation, error) { return c.Client.CreateInstance(instance) })
+	return c.wait(ctx, "CreateInstance", func() (incus.Operation, error) {
+		op, err := c.tryFindInstanceCreateOperation(ctx, instance.Name)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "Warning: failed to check for existing instance create operation")
+		} else if op != nil {
+			log.FromContext(ctx).V(2).Info("Found existing create operation")
+			return op, nil
+		}
+		return c.Client.CreateInstance(instance)
+	})
 }
 
 func (c *Client) ensureInstanceRunning(ctx context.Context, name string) error {
@@ -209,4 +218,38 @@ func (c *Client) serverSupportsExtensions(extensions ...string) ([]string, error
 	} else {
 		return sets.New(extensions...).Difference(sets.New(server.APIExtensions...)).UnsortedList(), nil
 	}
+}
+
+// List existing server operations to find if any CreateInstance operations are pending for the target instance name.
+// If anything fails, it will return the error that occured.
+// If any is active, it will return a waitable incus.Operation object.
+// If no operations are active, it will return nil.
+//
+// NOTE(neoaggelos/2025-02-15): Reference instance create operation metadata (for incus):
+// I0213 13:22:34.766849 3032651 client_test.go:39] "Starting" operation={"id":"b0fb6039-b45f-4ee0-89f5-d7b1b1dd164f","class":"task","description":"Creating instance","created_at":"2025-02-13T23:22:31.608899984+02:00","updated_at":"2025-02-13T23:22:34.764554068+02:00","status":"Running","status_code":103,"resources":{"instances":["/1.0/instances/t2"]},"metadata":{"create_instance_from_image_unpack_progress":"Unpacking image: 88%","progress":{"percent":"88","speed":"0","stage":"create_instance_from_image_unpack"}},"may_cancel":false,"err":"","location":"damocles"}
+func (c *Client) tryFindInstanceCreateOperation(ctx context.Context, instanceName string) (incus.Operation, error) {
+	ops, err := c.Client.GetOperations()
+	if err != nil {
+		return nil, fmt.Errorf("failed to GetOperations: %w", err)
+	}
+
+	instancePath := fmt.Sprintf("/1.0/instances/%s", instanceName)
+
+	for _, metadata := range ops {
+		if metadata.Class != "task" && metadata.Description != "Creating instance" {
+			continue
+		}
+		if instances := metadata.Resources["instances"]; len(instances) != 1 || instances[0] != instancePath {
+			continue
+		}
+
+		op, _, err := c.Client.RawOperation("GET", fmt.Sprintf("/operations/%s", metadata.ID), nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to GetOperation(%s): %w", metadata.ID, err)
+		}
+		log.FromContext(ctx).V(4).WithValues("operation", metadata).Info("Found existing instance create operation")
+
+		return op, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
- Set the CreatingInstance condition on the lxcMachine object, not the lxcCluster
- Check for existing CreateInstance operations, and tail them for progress if any
- When the operation times out, do not set the InstanceProvisioned to failed
