### PR TITLE
Add documentation for lxc-default cluster class and default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Rough steps for version v0.4.0:
 - [x] Add PR blocking CI pipelines.
 - [x] Publish v0.2.0 release with v1alpha2 APIs.
 - [x] Add e2e tests for cluster upgrades.
-- [ ] Explore clusters with ClusterTopology=true (clusterclass), also allows us to run all existing ClusterAPI e2e tests like Autoscaler, etc.
+- [x] Explore clusters with ClusterTopology=true (clusterclass), also allows us to run all existing ClusterAPI e2e tests like Autoscaler, etc.
 - [ ] Add cluster-templates for 3rd party providers, e.g. [Canonical Kubernetes](https://github.com/canonical/cluster-api-k8s).
 - [ ] Write documentation with setting up a development environment.
 - [ ] Write documentation with common troubleshooting steps.

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
 ---
 
 - [Cluster Templates](./reference/templates/index.md)
+  - [Default](./reference/templates/default.md)
   - [Development](./reference/templates/development.md)
   - [Kube VIP](./reference/templates/kube-vip.md)
   - [OVN Load Balancer](./reference/templates/ovn.md)

--- a/docs/book/src/reference/templates/default.md
+++ b/docs/book/src/reference/templates/default.md
@@ -1,0 +1,116 @@
+# Default cluster template
+
+The default cluster-template uses the [`lxc-default` cluster class](#cluster-class).
+
+All load balancer types are supported through configuration options. Further, it allows deploying the default kube-flannel CNI on the cluster.
+
+## Table Of Contents
+
+<!-- toc -->
+
+## Requirements
+
+1. ClusterAPI `ClusterTopology` Feature Gate is enabled (initialize providers with `CLUSTER_TOPOLOGY=true`).
+2. The management cluster can reach the load balancer endpoint, so that it can connect to the workload cluster.
+
+## Configuration
+
+```bash
+{{#include ../../../../../templates/cluster-template.rc }}
+```
+
+## Generate cluster
+
+```bash
+clusterctl generate cluster example-cluster -i lxc
+```
+
+## Configuration notes
+
+### `LXC_SECRET_NAME`
+
+Name of Kubernetes secret with [infrastructure credentials](../identity-secret.md#identity-secret-format).
+
+### `LOAD_BALANCER`
+
+You must choose between one of the options above to configure the load balancer for the infrastructure. See [Cluster Load Balancer Types](../../explanation/load-balancer.md) for more details.
+
+{{#tabs name:"load-balancer-type" tabs:"LXC,OCI,Kube VIP,OVN" }}
+
+{{#tab LXC }}
+
+Use an LXC container for the load balancer. The instance size will be 1 core, 1 GB RAM and will have the `default` profile attached.
+
+```bash
+export LOAD_BALANCER="lxc: {profiles: [default], flavor: c1-m1}"
+```
+
+{{#/tab }}
+
+{{#tab OCI }}
+
+Use an OCI container for the load balancer. The instance size will be 1 core, 1 GB RAM and will have the `default` profile attached.
+
+```bash
+export LOAD_BALANCER="oci: {profiles: [default], flavor: c1-m1}"
+```
+
+{{#/tab }}
+
+{{#tab Kube VIP }}
+
+Deploy `kube-vip` with static pods on the control plane nodes. The VIP address will be `10.0.42.1`.
+
+```bash
+export LOAD_BALANCER="kube-vip: {host: 10.0.42.1}"
+```
+
+{{#/tab }}
+
+{{#tab OVN }}
+
+Create an OVN network load balancer with IP `10.100.42.1` on the OVN network `ovn-0`.
+
+```bash
+export LOAD_BALANCER="ovn: {host: 10.100.42.1, networkName: ovn-0}"
+```
+
+{{#/tab }}
+
+{{#/tabs }}
+
+### `DEPLOY_KUBE_FLANNEL`
+
+Set `DEPLOY_KUBE_FLANNEL=true` to deploy the default kube-flannel CNI on the cluster. If not set, you must manually a CNI before the cluster is usable.
+
+### `LXC_IMAGE_NAME` and `INSTALL_KUBEADM`
+
+`LXC_IMAGE_NAME` must be set if creating a cluster with a Kubernetes version for which no [pre-built Kubeadm images](../default-simplestreams-server.md#provided-images) are available. It is recommended to build [custom images](../../howto/images/kubeadm.md) in this case.
+
+Alternatively, you can pick a default Ubuntu image with `ubuntu:24.04`, and set `INSTALL_KUBEADM=true` to inject `preKubeadmCommands` that install kubeadm and necessary tools on the instance prior to bootstrapping.
+
+### `CONTROL_PLANE_INSTANCE_TYPE` and `WORKER_INSTANCE_TYPE`
+
+These must be set to `container` or `virtual-machine`. Launch virtual machines requires `kvm` support on the node.
+
+It is customary that clusters use `container` instances for the control plane nodes, and `virtual-machine` for the worker nodes.
+
+### `CONTROL_PLANE_INSTANCE_PROFILES` and `WORKER_INSTANCE_PROFILES`
+
+A list of [profile](https://linuxcontainers.org/incus/docs/main/profiles/) names to attach to the created instances. The [default kubeadm profile](../profile/kubeadm.md) will be automatically added to the list, if not already present. For local development, this should be `[default]`.
+
+### `CONTROL_PLANE_INSTANCE_FLAVOR` and `WORKER_INSTANCE_FLAVOR`
+
+Instance size for the control plane and worker instances. This is typically specified as `cX-mY`, in which case the instance size will be `X cores` and `Y GB RAM`.
+
+## Cluster Template
+
+```yaml
+{{#include ../../../../../templates/cluster-template.yaml }}
+```
+
+## Cluster Class Definition
+
+```yaml
+{{#include ../../../../../templates/clusterclass-lxc-default.yaml }}
+```

--- a/docs/book/src/tutorial/quick-start.md
+++ b/docs/book/src/tutorial/quick-start.md
@@ -48,9 +48,12 @@ sudo kind create cluster --kubeconfig ~/.kube/config
 sudo chown $(id -u):$(id -g) ~/.kube/config
 ```
 
-Initialize kind cluster as a ClusterAPI management cluster with:
+Initialize kind cluster as a ClusterAPI management cluster:
 
 ```bash
+# Enable the ClusterTopology feature gate
+export CLUSTER_TOPOLOGY=true
+
 clusterctl init
 ```
 
@@ -103,7 +106,7 @@ Generate a Kubernetes secret `lxc-secret` with credentials to access the Incus H
 ```bash
 kubectl create secret generic lxc-secret \
   --from-literal=server="https://$(incus config get core.https_address)" \
-  --from-literal=server-crt="$(sudo cat /var/lib/incus/cluster.crt)" \
+  --from-literal=server-crt="$(cat ~/.config/incus/servercerts/local-https.crt)" \
   --from-literal=client-crt="$(cat ~/.config/incus/client.crt)" \
   --from-literal=client-key="$(cat ~/.config/incus/client.key)" \
   --from-literal=project="default"
@@ -144,7 +147,7 @@ Generate a Kubernetes secret `lxc-secret` with credentials to access the LXD HTT
 ```bash
 kubectl create secret generic lxc-secret \
   --from-literal=server="https://$(lxc config get core.https_address)" \
-  --from-literal=server-crt="$(sudo cat /var/snap/lxd/common/lxd/cluster.crt)" \
+  --from-literal=server-crt="$(cat ~/snap/lxd/common/config/servercerts/local-https.crt)" \
   --from-literal=client-crt="$(cat ~/snap/lxd/common/config/client.crt)" \
   --from-literal=client-key="$(cat ~/snap/lxd/common/config/client.key)" \
   --from-literal=project="default"
@@ -416,4 +419,4 @@ kind delete cluster
 
 - Expore the v1alpha2 [CRDs](../reference/api/v1alpha2/api.md)
 - See list of example [Cluster Templates](../reference/templates/index.md)
-- Read about the [Defaul Simplestreams Server](../reference/default-simplestreams-server.md)
+- Read about the [Default Simplestreams Server](../reference/default-simplestreams-server.md)


### PR DESCRIPTION
### Summary

Documentation for the `lxc-default` cluster class, and minor documentation fixes and adjustments