### PR TITLE
log reason for failing to create incus client

### DIFF
--- a/internal/controller/lxccluster/controller.go
+++ b/internal/controller/lxccluster/controller.go
@@ -93,7 +93,7 @@ func (r *LXCClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	lxcClient, err := incus.New(ctx, incus.NewOptionsFromSecret(lxcSecret))
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create incus client")
+		return ctrl.Result{}, fmt.Errorf("failed to create incus client: %w", err)
 	}
 
 	// Add finalizer first if not set to avoid the race condition between init and delete.

--- a/internal/controller/lxcmachine/controller.go
+++ b/internal/controller/lxcmachine/controller.go
@@ -141,7 +141,7 @@ func (r *LXCMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	lxcClient, err := incus.New(ctx, incus.NewOptionsFromSecret(lxcSecret))
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to create incus client")
+		return ctrl.Result{}, fmt.Errorf("failed to create incus client: %w", err)
 	}
 
 	// Add finalizer first if not set to avoid the race condition between init and delete.


### PR DESCRIPTION
### Summary

Add error context when failing to create infrastructure client