### PR TITLE
doc: handle breaking change in 5.21/stable lxd snap track

### DIFF
--- a/docs/book/src/tutorial/quick-start.md
+++ b/docs/book/src/tutorial/quick-start.md
@@ -137,8 +137,7 @@ Generate a client certificate and key, and add it as a trusted client certificat
 ```bash
 token="$(sudo lxc config trust add --name client | tail -1)"
 
-lxc remote add local-https "https://$(sudo lxc config get core.https_address)" \
-    --accept-certificate --token "$token"
+lxc remote add local-https --token "$token" "https://$(sudo lxc config get core.https_address)"
 lxc remote set-default local-https
 ```
 

--- a/hack/scripts/ci/setup-lxd.sh
+++ b/hack/scripts/ci/setup-lxd.sh
@@ -21,7 +21,7 @@ sudo lxc cluster enable "$ip_address"
 # Generate client certificate and key, trust certificate
 if ! lxc remote switch local-https; then
   token="$(sudo lxc config trust add --name client | tail -1)"
-  lxc remote add local-https "https://$(sudo lxc config get core.https_address)" --accept-certificate --token "$token"
+  lxc remote add local-https "https://$(sudo lxc config get core.https_address)" --token "$token"
   lxc remote set-default local-https
 fi
 


### PR DESCRIPTION
### Summary

A recent change was released in LXD 5.21/stable (introduced in the `5.21/stable` channel) breaks the following usage (/shrug) :

```bash
$ lxc remote add $name $address --token $token --accept-certificate
```

Example error message from failed CI run:

```
++ sudo lxc config get core.https_address
+ lxc remote add local-https https://10.1.0.67:8443/ --accept-certificate --token eyJjbGllbnRfbmFtZSI6ImNsaWVudCIsImZpbmdlcnByaW50IjoiMjNkNDdhMzZjNWRkYWFiZTBkNmRkZWE0ZTk5MDg2ZmEyYjg0MTA5NGY4ZTcwMDY3MzQwMjNiMjU2M2YyYmMyMyIsImFkZHJlc3NlcyI6WyIxMC4xLjAuNjc6ODQ0MyJdLCJzZWNyZXQiOiJhZTg3MjdiZjI0MjZiNjQ4NzkzNjAyMmQzMzg3MGUzNWQ4ZGVlMDQxYzI0MWUwN2NhYWQwZTUxMjhmYTE4NDgzIiwiZXhwaXJlc19hdCI6IjAwMDEtMDEtMDFUMDA6MDA6MDBaIiwidHlwZSI6IiJ9
Error: The --accept-certificate flag is not supported when adding a remote using a trust token
```

When testing manually, it looks like `--accept-certificate` is simply not required any more