### PR TITLE
Add lxcmachine.spec.devices

### DIFF
--- a/api/v1alpha2/lxcmachine_types.go
+++ b/api/v1alpha2/lxcmachine_types.go
@@ -61,6 +61,21 @@ type LXCMachineSpec struct {
 	// +optional
 	Profiles []string `json:"profiles,omitempty"`
 
+	// Devices allows overriding the configuration of the instance disk or network.
+	//
+	// Device configuration must be formatted using the syntax "<device>,<key>=<value>".
+	//
+	// For example, to specify a different network for an instance, you can use:
+	//
+	// ```yaml
+	//   # override device "eth0", to be of type "nic" and use network "my-network"
+	//   devices:
+	//   - eth0,type=nic,network=my-network
+	// ```
+	//
+	// +optional
+	Devices []string `json:"devices,omitempty"`
+
 	// Image to use for provisioning the machine. If not set, a kubeadm image
 	// from the default upstream simplestreams source will be used, based on
 	// the version of the machine.

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -432,6 +432,11 @@ func (in *LXCMachineSpec) DeepCopyInto(out *LXCMachineSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Devices != nil {
+		in, out := &in.Devices, &out.Devices
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.Image = in.Image
 }
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
@@ -60,6 +60,22 @@ spec:
           spec:
             description: LXCMachineSpec defines the desired state of LXCMachine.
             properties:
+              devices:
+                description: |-
+                  Devices allows overriding the configuration of the instance disk or network.
+
+                  Device configuration must be formatted using the syntax "<device>,<key>=<value>".
+
+                  For example, to specify a different network for an instance, you can use:
+
+                  ```yaml
+                    # override device "eth0", to be of type "nic" and use network "my-network"
+                    devices:
+                    - eth0,type=nic,network=my-network
+                  ```
+                items:
+                  type: string
+                type: array
               flavor:
                 description: |-
                   Flavor is configuration for the instance size (e.g. t3.micro, or c2-m4).

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
@@ -77,6 +77,22 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
+                      devices:
+                        description: |-
+                          Devices allows overriding the configuration of the instance disk or network.
+
+                          Device configuration must be formatted using the syntax "<device>,<key>=<value>".
+
+                          For example, to specify a different network for an instance, you can use:
+
+                          ```yaml
+                            # override device "eth0", to be of type "nic" and use network "my-network"
+                            devices:
+                            - eth0,type=nic,network=my-network
+                          ```
+                        items:
+                          type: string
+                        type: array
                       flavor:
                         description: |-
                           Flavor is configuration for the instance size (e.g. t3.micro, or c2-m4).

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -849,6 +849,24 @@ string
 </tr>
 <tr>
 <td>
+<code>devices</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Devices allows overriding the configuration of the instance disk or network.</p>
+<p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
+<p>For example, to specify a different network for an instance, you can use:</p>
+<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+devices:
+- eth0,type=nic,network=my-network
+</code></pre>
+</td>
+</tr>
+<tr>
+<td>
 <code>image</code><br/>
 <em>
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineImageSource">
@@ -1026,6 +1044,24 @@ string
 <td>
 <em>(Optional)</em>
 <p>Profiles is a list of profiles to attach to the instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>devices</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Devices allows overriding the configuration of the instance disk or network.</p>
+<p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
+<p>For example, to specify a different network for an instance, you can use:</p>
+<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+devices:
+- eth0,type=nic,network=my-network
+</code></pre>
 </td>
 </tr>
 <tr>
@@ -1290,6 +1326,24 @@ string
 <td>
 <em>(Optional)</em>
 <p>Profiles is a list of profiles to attach to the instance.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>devices</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Devices allows overriding the configuration of the instance disk or network.</p>
+<p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
+<p>For example, to specify a different network for an instance, you can use:</p>
+<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+devices:
+- eth0,type=nic,network=my-network
+</code></pre>
 </td>
 </tr>
 <tr>

--- a/docs/book/src/reference/templates/default.md
+++ b/docs/book/src/reference/templates/default.md
@@ -99,6 +99,24 @@ It is customary that clusters use `container` instances for the control plane no
 
 A list of [profile](https://linuxcontainers.org/incus/docs/main/profiles/) names to attach to the created instances. The [default kubeadm profile](../profile/kubeadm.md) will be automatically added to the list, if not already present. For local development, this should be `[default]`.
 
+### `CONTROL_PLANE_INSTANCE_DEVICES` and `WORKER_INSTANCE_DEVICES`
+
+A list of [device](https://linuxcontainers.org/incus/docs/main/reference/devices/) configuration overrides for the created instances. This can be used to override the network interface or the root disk of the instance.
+
+Devices are specified as an array of strings with the following syntax: `<device>,<key>=<value>`. For example, to override the network of the created instances, you can specify:
+
+```bash
+export CONTROL_PLANE_INSTANCE_DEVICES="['eth0,type=nic,network=my-network']"
+export WORKER_INSTANCE_DEVICES="['eth0,type=nic,network=my-network']"
+```
+
+Similarly, to override the network and also specify a custom root disk size, you can use:
+
+```bash
+export CONTROL_PLANE_INSTANCE_DEVICES="['eth0,type=nic,network=my-network', 'root,type=disk,path=/,pool=local,size=50GB']"
+export WORKER_INSTANCE_DEVICES="['eth0,type=nic,network=my-network', 'root,type=disk,path=/,pool=local,size=50GB']"
+```
+
 ### `CONTROL_PLANE_INSTANCE_FLAVOR` and `WORKER_INSTANCE_FLAVOR`
 
 Instance size for the control plane and worker instances. This is typically specified as `cX-mY`, in which case the instance size will be `X cores` and `Y GB RAM`.

--- a/docs/book/src/tutorial/quick-start.md
+++ b/docs/book/src/tutorial/quick-start.md
@@ -218,6 +218,7 @@ Required Variables:
 Optional Variables:
   - CLUSTER_NAME                    (defaults to c1)
   - CONTROL_PLANE_MACHINE_COUNT     (defaults to 1)
+  - CONTROL_PLANE_MACHINE_DEVICES   (defaults to "[]")
   - CONTROL_PLANE_MACHINE_PROFILES  (defaults to "[default]")
   - LOAD_BALANCER_MACHINE_FLAVOR    (defaults to "")
   - LOAD_BALANCER_MACHINE_PROFILES  (defaults to "[default]")
@@ -226,6 +227,7 @@ Optional Variables:
   - POD_CIDR                        (defaults to "[10.244.0.0/16]")
   - SERVICE_CIDR                    (defaults to "[10.96.0.0/12]")
   - WORKER_MACHINE_COUNT            (defaults to 0)
+  - WORKER_MACHINE_DEVICES          (defaults to "[]")
   - WORKER_MACHINE_PROFILES         (defaults to "[default]")
 ```
 

--- a/templates/cluster-template-autoscaler.yaml
+++ b/templates/cluster-template-autoscaler.yaml
@@ -34,6 +34,7 @@ spec:
         type: ${CONTROL_PLANE_MACHINE_TYPE:=container}
         flavor: ${CONTROL_PLANE_MACHINE_FLAVOR:=c2-m4}
         profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+        devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
         image: ${LXC_IMAGE_NAME:=""}
         installKubeadm: ${INSTALL_KUBEADM:=false}
 
@@ -57,5 +58,6 @@ spec:
               type: ${WORKER_MACHINE_TYPE:=container}
               flavor: ${WORKER_MACHINE_FLAVOR:=c2-m4}
               profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+              devices: ${WORKER_MACHINE_DEVICES:=[]}
               image: ${LXC_IMAGE_NAME:=""}
               installKubeadm: ${INSTALL_KUBEADM:=false}

--- a/templates/cluster-template-development.rc
+++ b/templates/cluster-template-development.rc
@@ -16,10 +16,12 @@ export LOAD_BALANCER_MACHINE_FLAVOR=c1-m1       # instance type for the lb conta
 
 # Control plane machine configuration
 export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machine'
-export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
+export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
+export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
 
 # Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
-export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
+export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
+export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes

--- a/templates/cluster-template-development.yaml
+++ b/templates/cluster-template-development.yaml
@@ -82,6 +82,7 @@ spec:
       instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
       flavor: ${CONTROL_PLANE_MACHINE_FLAVOR}
       profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+      devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---
@@ -118,6 +119,7 @@ spec:
       instanceType: ${WORKER_MACHINE_TYPE}
       flavor: ${WORKER_MACHINE_FLAVOR}
       profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+      devices: ${WORKER_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---

--- a/templates/cluster-template-kube-vip.rc
+++ b/templates/cluster-template-kube-vip.rc
@@ -15,10 +15,12 @@ export LXC_LOAD_BALANCER_INTERFACE=             # (optional) specify interface t
 
 # Control plane machine configuration
 export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machine'
-export CONTROL_PLANE_MACHINE_PROFILES=default   # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
+export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
+export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
 
 # Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
-export WORKER_MACHINE_PROFILES=default          # profiles for worker nodes
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
+export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
+export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -171,6 +171,7 @@ spec:
       instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
       flavor: ${CONTROL_PLANE_MACHINE_FLAVOR}
       profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+      devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---
@@ -207,6 +208,7 @@ spec:
       instanceType: ${WORKER_MACHINE_TYPE}
       flavor: ${WORKER_MACHINE_FLAVOR}
       profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+      devices: ${WORKER_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---

--- a/templates/cluster-template-ovn.rc
+++ b/templates/cluster-template-ovn.rc
@@ -15,10 +15,12 @@ export LXC_LOAD_BALANCER_NETWORK=ovn0           # name of the ovn network used b
 
 # Control plane machine configuration
 export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machine'
-export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
+export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
+export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
 
 # Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
-export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
+export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
+export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes

--- a/templates/cluster-template-ovn.yaml
+++ b/templates/cluster-template-ovn.yaml
@@ -83,6 +83,7 @@ spec:
       instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
       flavor: ${CONTROL_PLANE_MACHINE_FLAVOR}
       profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+      devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---
@@ -119,6 +120,7 @@ spec:
       instanceType: ${WORKER_MACHINE_TYPE}
       flavor: ${WORKER_MACHINE_FLAVOR}
       profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+      devices: ${WORKER_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME:=""}
 ---

--- a/templates/cluster-template-ubuntu.rc
+++ b/templates/cluster-template-ubuntu.rc
@@ -18,10 +18,12 @@ export LOAD_BALANCER_MACHINE_FLAVOR=c1-m1       # instance type for the lb conta
 
 # Control plane machine configuration
 export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machine'
-export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
+export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
+export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
 
 # Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
-export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
+export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
+export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes

--- a/templates/cluster-template-ubuntu.yaml
+++ b/templates/cluster-template-ubuntu.yaml
@@ -85,6 +85,7 @@ spec:
       instanceType: ${CONTROL_PLANE_MACHINE_TYPE}
       flavor: ${CONTROL_PLANE_MACHINE_FLAVOR}
       profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+      devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME}
 ---
@@ -121,6 +122,7 @@ spec:
       instanceType: ${WORKER_MACHINE_TYPE}
       flavor: ${WORKER_MACHINE_FLAVOR}
       profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+      devices: ${WORKER_MACHINE_DEVICES:=[]}
       image:
         name: ${LXC_IMAGE_NAME}
 ---

--- a/templates/cluster-template.rc
+++ b/templates/cluster-template.rc
@@ -26,12 +26,14 @@ export WORKER_MACHINE_COUNT=1
 #export LXC_IMAGE_NAME="ubuntu:24.04"
 #export INSTALL_KUBEADM="true"
 
-## Control plane machine configuration
+# Control plane machine configuration
 export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machine'
-export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
+export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
+export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
 
-## Worker machine configuration
+# Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
-export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
+export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
+export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -34,6 +34,7 @@ spec:
         type: ${CONTROL_PLANE_MACHINE_TYPE:=container}
         flavor: ${CONTROL_PLANE_MACHINE_FLAVOR:=c2-m4}
         profiles: ${CONTROL_PLANE_MACHINE_PROFILES:=[default]}
+        devices: ${CONTROL_PLANE_MACHINE_DEVICES:=[]}
         image: ${LXC_IMAGE_NAME:=""}
         installKubeadm: ${INSTALL_KUBEADM:=false}
 
@@ -54,5 +55,6 @@ spec:
               type: ${WORKER_MACHINE_TYPE:=container}
               flavor: ${WORKER_MACHINE_FLAVOR:=c2-m4}
               profiles: ${WORKER_MACHINE_PROFILES:=[default]}
+              devices: ${WORKER_MACHINE_DEVICES:=[]}
               image: ${LXC_IMAGE_NAME:=""}
               installKubeadm: ${INSTALL_KUBEADM:=false}

--- a/templates/clusterclass-lxc-default.yaml
+++ b/templates/clusterclass-lxc-default.yaml
@@ -142,6 +142,11 @@ spec:
             items:
               type: string
             description: List of profiles to apply on the instance
+          devices:
+            type: array
+            items:
+              type: string
+            description: Override device (e.g. network, storage) configuration for the instance
           installKubeadm:
             type: boolean
             default: false
@@ -575,6 +580,7 @@ spec:
         valueFrom:
           template: |
             profiles: {{ .instance.profiles | toJson }}
+            devices: {{ .instance.devices | toJson }}
             instanceType: {{ .instance.type | quote }}
             flavor: {{ .instance.flavor | quote }}
             image:
@@ -595,6 +601,7 @@ spec:
         valueFrom:
           template: |
             profiles: {{ .instance.profiles | toJson }}
+            devices: {{ .instance.devices | toJson }}
             instanceType: {{ .instance.type | quote }}
             flavor: {{ .instance.flavor | quote }}
             image:


### PR DESCRIPTION
### Summary

The field can be used to override the network or the storage configuration of launched instances, without requiring setting up and managing profiles.

The field is added in a fully backwards-compatible way.

### Notes

We can use this field to simplify the logic or e2e tests for OVN network load balancers