### PR TITLE
Add ClusterClassRollout e2e test

### DIFF
--- a/test/e2e/suites/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/suites/e2e/clusterclass_rollout_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var _ = Describe("ClusterClassRollout", Label("PRBlocking"), func() {
+var _ = Describe("ClusterClassRollout", func() {
 	e2e.ClusterClassRolloutSpec(context.TODO(), func() e2e.ClusterClassRolloutSpecInput {
 		return e2e.ClusterClassRolloutSpecInput{
 			E2EConfig:              e2eCtx.E2EConfig,

--- a/test/e2e/suites/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/suites/e2e/clusterclass_rollout_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+
+	"sigs.k8s.io/cluster-api/test/e2e"
+
+	"github.com/neoaggelos/cluster-api-provider-lxc/internal/ptr"
+	"github.com/neoaggelos/cluster-api-provider-lxc/test/e2e/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("ClusterClassRollout", Label("PRBlocking"), func() {
+	e2e.ClusterClassRolloutSpec(context.TODO(), func() e2e.ClusterClassRolloutSpecInput {
+		return e2e.ClusterClassRolloutSpecInput{
+			E2EConfig:              e2eCtx.E2EConfig,
+			ClusterctlConfigPath:   e2eCtx.Environment.ClusterctlConfigPath,
+			BootstrapClusterProxy:  e2eCtx.Environment.BootstrapClusterProxy,
+			ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
+			SkipCleanup:            e2eCtx.Settings.SkipCleanup,
+			PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
+			ControlPlaneWaiters:    e2eCtx.DefaultControlPlaneWaiters(),
+			InfrastructureProvider: ptr.To("lxc:v0.88.99"),
+
+			Flavor: shared.FlavorDefault,
+		}
+	})
+})


### PR DESCRIPTION
### Summary

Add an e2e test for the ClusterClassRollout e2e spec, to ensure that ClusterClass works as expected.