### PR TITLE
upgrade sigs.k8s.io/cluster-api v1.9.5 -> v1.9.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	k8s.io/client-go v0.32.0
 	k8s.io/component-base v0.31.4
 	k8s.io/klog/v2 v2.130.1
-	sigs.k8s.io/cluster-api v1.9.5
-	sigs.k8s.io/cluster-api/test v1.9.5
+	sigs.k8s.io/cluster-api v1.9.6
+	sigs.k8s.io/cluster-api/test v1.9.6
 	sigs.k8s.io/controller-runtime v0.19.6
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -473,10 +473,10 @@ k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJ
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 h1:2770sDpzrjjsAtVhSeUFseziht227YAWYHLGNM8QPwY=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
-sigs.k8s.io/cluster-api v1.9.5 h1:68164Q201Y5ANVkhyrOZenoMbfL2SEBjVYZs/ihhSro=
-sigs.k8s.io/cluster-api v1.9.5/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
-sigs.k8s.io/cluster-api/test v1.9.5 h1:DtiiDWCIGaWhp4cA7xzGPWeM796XIRQwOptLATe0yFg=
-sigs.k8s.io/cluster-api/test v1.9.5/go.mod h1:YL2wANe8TFWFBka9CDkxjPj7KALqUtK+PtKa4ChNIok=
+sigs.k8s.io/cluster-api v1.9.6 h1:2jZ434qC0bzrPQzmRDm4/b0PZWVMnOocoCjsAonQN5Q=
+sigs.k8s.io/cluster-api v1.9.6/go.mod h1:DyqyZ4jRvKGKewDRn1Q4OCHaVjsdTogymbO6mrgHEDI=
+sigs.k8s.io/cluster-api/test v1.9.6 h1:bnplAOqKRBFWP2q2L8kbY2DZTLBY8JTpucnGSLgS/Kw=
+sigs.k8s.io/cluster-api/test v1.9.6/go.mod h1:YL2wANe8TFWFBka9CDkxjPj7KALqUtK+PtKa4ChNIok=
 sigs.k8s.io/controller-runtime v0.19.6 h1:fuq53qTLQ7aJTA7aNsklNnu7eQtSFqJUomOyM+phPLk=
 sigs.k8s.io/controller-runtime v0.19.6/go.mod h1:iRmWllt8IlaLjvTTDLhRBXIEtkCK6hwVBJJsYS9Ajf4=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=

--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -4,11 +4,11 @@
 managementClusterName: capl-e2e
 
 images:
-- name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.5
+- name: registry.k8s.io/cluster-api/cluster-api-controller:v1.9.6
   loadBehavior: tryLoad
-- name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.5
+- name: registry.k8s.io/cluster-api/kubeadm-bootstrap-controller:v1.9.6
   loadBehavior: tryLoad
-- name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.5
+- name: registry.k8s.io/cluster-api/kubeadm-control-plane-controller:v1.9.6
   loadBehavior: tryLoad
 # Keep cert-manager images in lock-step with ClusterAPI version
 - name: quay.io/jetstack/cert-manager-cainjector:v1.16.3
@@ -25,8 +25,8 @@ providers:
 - name: cluster-api
   type: CoreProvider
   versions:
-  - name: v1.9.5
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/core-components.yaml"
+  - name: v1.9.6
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/core-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -37,8 +37,8 @@ providers:
 - name: kubeadm
   type: BootstrapProvider
   versions:
-  - name: v1.9.5
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/bootstrap-components.yaml"
+  - name: v1.9.6
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/bootstrap-components.yaml"
     type: url
     contract: v1beta1
     files:
@@ -49,8 +49,8 @@ providers:
 - name: kubeadm
   type: ControlPlaneProvider
   versions:
-  - name: v1.9.5
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.5/control-plane-components.yaml"
+  - name: v1.9.6
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.6/control-plane-components.yaml"
     type: url
     contract: v1beta1
     files:


### PR DESCRIPTION
## Summary

Upgrade cluster-api to latest version