### PR TITLE
Set Go 1.23.4 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/neoaggelos/cluster-api-provider-lxc
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/lxc/incus/v6 v6.8.0


### PR DESCRIPTION
### Summary

 Avoid having separate `go` and `toolchain` directives, as that affects the Go toolchain setup in Github Actions

Example issue https://github.com/neoaggelos/cluster-api-provider-lxc/actions/runs/14014130644/job/39237605481#annotation:3:9914