### PR TITLE
Remove "set -x" from postKubeadmCommands

### DIFF
--- a/templates/clusterclass-lxc-default.yaml
+++ b/templates/clusterclass-lxc-default.yaml
@@ -340,6 +340,7 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-
         value: |
+          set -x
           if [ -f /run/kubeadm/kubeadm.yaml ]; then
             kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /run/kubeadm/kube-flannel.yaml
           fi
@@ -696,8 +697,7 @@ spec:
           if systemd-detect-virt -c -q 2>/dev/null && [ -f /run/kubeadm/kubeadm.yaml ]; then
             cat /run/kubeadm/hack-kube-proxy-config-lxc.yaml | tee -a /run/kubeadm/kubeadm.yaml
           fi
-        postKubeadmCommands:
-        - set -x
+        postKubeadmCommands: []
         files:
         - path: /run/kubeadm/hack-kube-proxy-config-lxc.yaml
           content: |


### PR DESCRIPTION
### Summary

Observed an issue where a failing cloud-init would not mark cloud-init status as failed, since execution moved on and the next commands would not fail.

There is probably more investigation to properly mitigate this, but the current fix is good enough to restore functionality.
