### PR TITLE
Use a ZFS storage pool for e2e tests

### DIFF
--- a/hack/scripts/ci/setup-e2e-resources.sh
+++ b/hack/scripts/ci/setup-e2e-resources.sh
@@ -8,6 +8,10 @@
 # instance profiles
 LXC_PROFILE_NAME=default
 
+# zfs storage pool
+LXC_STORAGE_POOL_NAME=zfs
+LXC_STORAGE_POOL_SIZE=20GiB
+
 # local bridge network (10.200.1.0/24)
 LXC_NETWORK_NAME="testbr0"
 LXC_NETWORK_IPV6="none"
@@ -21,6 +25,17 @@ LXC_OVN_NETWORK_NAME="testovn0"
 LXC_OVN_NETWORK_IPV6="none"
 LXC_OVN_NETWORK_IPV4="192.168.200.1/24"
 LXC_OVN_NETWORK_IPV4_LB="10.200.1.201"
+
+########################################################################
+
+# configure storage
+if ! "${CLI}" storage show "${LXC_STORAGE_POOL_NAME}" 2> /dev/null; then
+  if ! "${CLI}" storage create "${LXC_STORAGE_POOL_NAME}" zfs size="${LXC_STORAGE_POOL_SIZE}"; then
+    echo "Failed to create ZFS storage pool, will use default storage"
+  else
+    "${CLI}" profile device set "${LXC_PROFILE_NAME}" root type=disk pool="${LXC_STORAGE_POOL_NAME}"
+  fi
+fi
 
 ########################################################################
 

--- a/hack/scripts/ci/setup-incus.sh
+++ b/hack/scripts/ci/setup-incus.sh
@@ -2,6 +2,11 @@
 
 DIR="$(dirname "$(realpath "$0")")"
 
+if ! which zpool; then
+  sudo apt update
+  sudo apt install zfsutils-linux --yes --no-install-recommends
+fi
+
 if ! which incus; then
   curl https://pkgs.zabbly.com/get/incus-stable | sudo bash -x
 fi

--- a/hack/scripts/ci/setup-incus.sh
+++ b/hack/scripts/ci/setup-incus.sh
@@ -38,4 +38,4 @@ data:
 " | tee "${DIR}/../../../lxc-secret.yaml"
 
 # Setup local Incus daemon for e2e tests
-CLI=incus "${DIR}/setup-e2e.sh"
+CLI=incus "${DIR}/setup-e2e-resources.sh"

--- a/hack/scripts/ci/setup-lxd.sh
+++ b/hack/scripts/ci/setup-lxd.sh
@@ -41,4 +41,4 @@ data:
 " | tee "${DIR}/../../../lxc-secret.yaml"
 
 # Setup local LXD daemon for e2e tests
-CLI=lxc "${DIR}/setup-e2e.sh"
+CLI=lxc "${DIR}/setup-e2e-resources.sh"


### PR DESCRIPTION
### Summary

ZFS cow creates lightweight clones when spawning instances. which greatly reduces storage size requirements for e2e tests.

This also speeds up e2e tests since lightweight clones are much faster than copying the kubeadm image.

Split from #44 
