### PR TITLE
Use latest kubeadm/v1.32.3 image for cluster templates and docs

### DIFF
--- a/docs/book/src/howto/developer-guide.md
+++ b/docs/book/src/howto/developer-guide.md
@@ -125,7 +125,7 @@ On a separate window, generate a cluster manifest and deploy:
 ```bash
 export LOAD_BALANCER="lxc: {}"
 export LXC_SECRET_NAME="lxc-secret"
-export KUBERNETES_VERSION="v1.32.2"
+export KUBERNETES_VERSION="v1.32.3"
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-development.rc
+++ b/templates/cluster-template-development.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.0
+export KUBERNETES_VERSION=v1.32.3
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-kube-vip.rc
+++ b/templates/cluster-template-kube-vip.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.0
+export KUBERNETES_VERSION=v1.32.3
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-ovn.rc
+++ b/templates/cluster-template-ovn.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.0
+export KUBERNETES_VERSION=v1.32.3
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-ubuntu.rc
+++ b/templates/cluster-template-ubuntu.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.0
+export KUBERNETES_VERSION=v1.32.3
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template.rc
+++ b/templates/cluster-template.rc
@@ -1,5 +1,5 @@
 ## Cluster version and size
-export KUBERNETES_VERSION=v1.32.0
+export KUBERNETES_VERSION=v1.32.3
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 


### PR DESCRIPTION
### Summary

Update docs and templates to use kubeadm v1.32.3 image