### PR TITLE
fix DEPLOY_KUBE_FLANNEL in default cluster template

### DIFF
--- a/templates/clusterclass-lxc-default.yaml
+++ b/templates/clusterclass-lxc-default.yaml
@@ -348,7 +348,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-
         value: |
-          set -x
           if [ -f /run/kubeadm/kubeadm.yaml ]; then
             kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /run/kubeadm/kube-flannel.yaml
           fi
@@ -760,13 +759,14 @@ spec:
           patches:
             directory: /etc/kubernetes/patches
         preKubeadmCommands:
-        - set -x
+        - set -ex
         # Workaround for kube-proxy failing to configure nf_conntrack_max_per_core on LXC
         - |
           if systemd-detect-virt -c -q 2>/dev/null && [ -f /run/kubeadm/kubeadm.yaml ]; then
             cat /run/kubeadm/hack-kube-proxy-config-lxc.yaml | tee -a /run/kubeadm/kubeadm.yaml
           fi
-        postKubeadmCommands: []
+        postKubeadmCommands:
+        - set -x
         files:
         - path: /etc/kubernetes/patches/.placeholder
           content: placeholder file to prevent kubeadm path not found errors


### PR DESCRIPTION
### Summary

Fixes regression introduced in #46 

`DEPLOY_KUBE_FLANNEL=true` would try to append to an empty list, raising the following condition:

```yaml
    - lastTransitionTime: "2025-04-09T11:25:38Z"
      message: 'error computing the desired state of the Cluster topology: failed
        to apply patches: failed to apply patches for patch "controlPlaneKubeFlannel":
        failed to apply patch: error applying json patch (RFC6902): add operation
        does not apply: doc is missing path: "/spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-":
        missing value'
      observedGeneration: 1
      reason: ReconcileFailed
      status: "False"
      type: TopologyReconciled
```